### PR TITLE
Move PubMed workflow and restore publications data

### DIFF
--- a/.github/workflows/update_pubmed_publications.yml
+++ b/.github/workflows/update_pubmed_publications.yml
@@ -1,0 +1,48 @@
+name: Update PubMed Publications
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  fetch_pubmed_publications:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install biopython
+
+      - name: Fetch publications from PubMed
+        run: |
+          python - << 'EOF'
+          from Bio import Entrez
+
+          # Set your email (required by NCBI)
+          Entrez.email = "your-email@example.com"
+
+          # Define your query for the author "Satvik Tripathi"
+          query = '"Satvik Tripathi"[Author]'
+
+          # Search PubMed for matching records (retmax sets the maximum number of results)
+          handle = Entrez.esearch(db="pubmed", term=query, retmax=20)
+          record = Entrez.read(handle)
+          id_list = record.get('IdList', [])
+          
+          if not id_list:
+              print("No publications found for Satvik Tripathi.")
+          else:
+              print("Found publications with PubMed IDs:")
+              for pub_id in id_list:
+                  print(f"- {pub_id}")
+          EOF
+

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,47 +1,22 @@
-name: Update PubMed Publications
+main:
+  - title: Continual Learning for Abdominal Multi-Organ and Tumor Segmentation
+    authors: "Yixiao Zhang, Xinyi Li, Huimiao Chen, Alan Yuille, <strong>Yaoyao Liu*</strong>, Zongwei Zhou* (*Corresponding authors)"
+    conference_short: MICCAI
+    conference: International Conference on Medical Image Computing and Computer-Assisted Intervention <strong>(MICCAI)</strong>, 2023.
+    pdf: https://arxiv.org/pdf/2306.00988.pdf
+    code: https://github.com/MrGiovanni/ContinualLearning
+    bibtex: https://bib.yliu.me/MICCAI23.txt
+    image: ./assets/img/teaser_example_2.png
+    notes: Early Accept
 
-on:
-  schedule:
-    - cron: '0 0 * * *'  # Runs daily at midnight UTC
-  workflow_dispatch:
+  - title: "Mnemonics Training: Multi-Class Incremental Learning without Forgetting"
+    authors: "<strong>Yaoyao Liu</strong>, Yuting Su, An-An Liu, Bernt Schiele, Qianru Sun"
+    conference_short: CVPR
+    conference: IEEE/CVF Conference on Computer Vision and Pattern Recognition <strong>(CVPR)</strong>, 2020.
+    pdf: https://arxiv.org/pdf/2002.10211.pdf
+    code: https://github.com/yaoyao-liu/class-incremental-learning/tree/main/mnemonics-training
+    page: https://class-il.mpi-inf.mpg.de/mnemonics/
+    bibtex: https://class-il.mpi-inf.mpg.de/mnemonics/
+    notes: Oral Presentation
+    image: ./assets/img/teaser_example.png
 
-jobs:
-  fetch_pubmed_publications:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install biopython
-
-      - name: Fetch publications from PubMed
-        run: |
-          python - << 'EOF'
-          from Bio import Entrez
-
-          # Set your email (required by NCBI)
-          Entrez.email = "your-email@example.com"
-
-          # Define your query for the author "Satvik Tripathi"
-          query = '"Satvik Tripathi"[Author]'
-
-          # Search PubMed for matching records (retmax sets the maximum number of results)
-          handle = Entrez.esearch(db="pubmed", term=query, retmax=20)
-          record = Entrez.read(handle)
-          id_list = record.get('IdList', [])
-          
-          if not id_list:
-              print("No publications found for Satvik Tripathi.")
-          else:
-              print("Found publications with PubMed IDs:")
-              for pub_id in id_list:
-                  print(f"- {pub_id}")
-          EOF

--- a/_includes/publications.md
+++ b/_includes/publications.md
@@ -3,41 +3,41 @@
 <div class="publications">
 <ol class="bibliography">
 
-{% for link in site.data.publications.main %}
+{% for pub in site.data.publications.main %}
 
 <li>
 <div class="pub-row">
   <div class="col-sm-3 abbr" style="position: relative;padding-right: 15px;padding-left: 15px;">
-    {% if link.image %} 
-    <img src="{{ link.image }}" class="teaser img-fluid z-depth-1" style="width=100;height=40%">
+    {% if pub.image %}
+    <img src="{{ pub.image }}" class="teaser img-fluid z-depth-1" style="width=100;height=40%">
     {% endif %}
-    {% if link.conference_short %} 
-    <abbr class="badge">{{ link.conference_short }}</abbr>
+    {% if pub.conference_short %}
+    <abbr class="badge">{{ pub.conference_short }}</abbr>
     {% endif %}
   </div>
   <div class="col-sm-9" style="position: relative;padding-right: 15px;padding-left: 20px;">
-      <div class="title"><a href="{{ link.pdf }}">{{ link.title }}</a></div>
-      <div class="author">{{ link.authors }}</div>
-      <div class="periodical"><em>{{ link.conference }}</em>
+      <div class="title"><a href="{{ pub.pdf }}">{{ pub.title }}</a></div>
+      <div class="author">{{ pub.authors }}</div>
+      <div class="periodical"><em>{{ pub.conference }}</em>
       </div>
     <div class="links">
-      {% if link.pdf %} 
-      <a href="{{ link.pdf }}" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">PDF</a>
+      {% if pub.pdf %}
+      <a href="{{ pub.pdf }}" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">PDF</a>
       {% endif %}
-      {% if link.code %} 
-      <a href="{{ link.code }}" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">Code</a>
+      {% if pub.code %}
+      <a href="{{ pub.code }}" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">Code</a>
       {% endif %}
-      {% if link.page %} 
-      <a href="{{ link.page }}" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">Project Page</a>
+      {% if pub.page %}
+      <a href="{{ pub.page }}" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">Project Page</a>
       {% endif %}
-      {% if link.bibtex %} 
-      <a href="{{ link.bibtex }}" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">BibTex</a>
+      {% if pub.bibtex %}
+      <a href="{{ pub.bibtex }}" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">BibTex</a>
       {% endif %}
-      {% if link.notes %} 
-      <strong> <i style="color:#e74d3c">{{ link.notes }}</i></strong>
+      {% if pub.notes %}
+      <strong> <i style="color:#e74d3c">{{ pub.notes }}</i></strong>
       {% endif %}
-      {% if link.others %} 
-      {{ link.others }}
+      {% if pub.others %}
+      {{ pub.others }}
       {% endif %}
     </div>
   </div>
@@ -50,4 +50,3 @@
 
 </ol>
 </div>
-


### PR DESCRIPTION
## Summary
- move PubMed fetch job into dedicated workflow
- restore publications data under a `main` array
- iterate over new `main` data and clean publication links

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6896d95b8df08328b66db967ff051839