### PR TITLE
Revamp homepage layout for responsive profile header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ auto_dark_mode: false
 
 # Font
 # You can use this option to choose between Serif or Sans Serif fonts.
-font: "San Serif" # or "Sans Serif"
+font: "Sans Serif" # or "Sans Serif"
 
 # Google Analytics ID
 # Please remove this if you don't use Google Analytics

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -37,61 +37,49 @@
   </head>
   <body>
     <div class="wrapper">
-      <header>
-        
+      <header class="profile-header">
         {% if site.avatar %}
-        <a class="image avatar"><img src="{{ site.avatar }}" alt="avatar" /></a>
+        <img class="avatar" src="{{ site.avatar }}" alt="avatar" />
         {% endif %}
-
-        <h1>{{ site.title }}</h1>
-
-        {% if site.position %}
-        <position style="font-size:1.10rem;">{{ site.position }}</position>
-        <br>
-        {% endif %}
-        {% if site.affiliation %}
-        <a href="{{ site.affiliation_link }}" rel="noopener"><autocolor>{{ site.affiliation }}</autocolor></a>
-        <br>
-        {% endif %}
-        {% if site.email %}
-        <email>{{ site.email }}</email>
-        {% endif %}
-
-        <br>
-        <br>
-        <div class="social-icons">
-        {% if site.google_scholar %}
-        <a style="margin: 0 5px 0 0" href="{{ site.google_scholar }}">
-          <i class="ai ai-google-scholar" style="font-size:1.2rem"></i>
-        </a>  
-        {% endif %}
-
-        {% if site.cv_link %}
-        <a style="margin: 0 5px 0 0" href="{{ site.cv_link }}">
-          <i class="ai ai-cv" style="font-size:1.3rem;"></i>
-        </a>
-        {% endif %}
-
-        {% if site.github_link %}
-        <a style="margin: 0 5px 0 0" href="{{ site.github_link }}">
-          <i class="fab fa-github"></i>
-        </a>
-        {% endif %}
-
-        {% if site.linkedin %}
-        <a style="margin: 0 5px 0 0" href="{{ site.linkedin }}">
-          <i class="fab fa-linkedin"></i>
-        </a>
-        {% endif %}
-
-        {% if site.twitter %}
-        <a style="margin: 0 0 0 0" href="{{ site.twitter }}">
-          <i class="fab fa-twitter"></i>
-        </a>
-        {% endif %}
+        <div class="profile-details">
+          <h1>{{ site.title }}</h1>
+          {% if site.position %}
+          <position>{{ site.position }}</position>
+          {% endif %}
+          {% if site.affiliation %}
+          <a href="{{ site.affiliation_link }}" rel="noopener"><autocolor>{{ site.affiliation }}</autocolor></a>
+          {% endif %}
+          {% if site.email %}
+          <email>{{ site.email }}</email>
+          {% endif %}
+          <div class="social-icons">
+            {% if site.google_scholar %}
+            <a href="{{ site.google_scholar }}">
+              <i class="ai ai-google-scholar" style="font-size:1.2rem"></i>
+            </a>
+            {% endif %}
+            {% if site.cv_link %}
+            <a href="{{ site.cv_link }}">
+              <i class="ai ai-cv" style="font-size:1.3rem;"></i>
+            </a>
+            {% endif %}
+            {% if site.github_link %}
+            <a href="{{ site.github_link }}">
+              <i class="fab fa-github"></i>
+            </a>
+            {% endif %}
+            {% if site.linkedin %}
+            <a href="{{ site.linkedin }}">
+              <i class="fab fa-linkedin"></i>
+            </a>
+            {% endif %}
+            {% if site.twitter %}
+            <a href="{{ site.twitter }}">
+              <i class="fab fa-twitter"></i>
+            </a>
+            {% endif %}
+          </div>
         </div>
-        <br>
-
       </header>
       <section>
 

--- a/assets/css/style-no-dark-mode.scss
+++ b/assets/css/style-no-dark-mode.scss
@@ -2,3 +2,76 @@
 ---
 
 @import "minimal-light-no-dark-mode";
+
+body {
+  background-color: #f8f9fa;
+  color: #333;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.wrapper {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+.profile-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.profile-header .avatar {
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+
+.profile-details {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.profile-details position,
+.profile-details email {
+  display: block;
+  margin-top: 0.25rem;
+  color: #666;
+}
+
+.social-icons {
+  margin-top: 1rem;
+}
+
+.social-icons a {
+  color: #555;
+  margin: 0 8px;
+  transition: color 0.2s ease;
+}
+
+.social-icons a:hover {
+  color: #0077b5;
+}
+
+@media (min-width: 768px) {
+  .profile-header {
+    flex-direction: row;
+    text-align: left;
+  }
+  .profile-header .avatar {
+    margin-right: 2rem;
+  }
+  .profile-details {
+    align-items: flex-start;
+  }
+}
+

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,3 +2,76 @@
 ---
 
 @import "minimal-light";
+
+body {
+  background-color: #f8f9fa;
+  color: #333;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.wrapper {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+.profile-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.profile-header .avatar {
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+
+.profile-details {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.profile-details position,
+.profile-details email {
+  display: block;
+  margin-top: 0.25rem;
+  color: #666;
+}
+
+.social-icons {
+  margin-top: 1rem;
+}
+
+.social-icons a {
+  color: #555;
+  margin: 0 8px;
+  transition: color 0.2s ease;
+}
+
+.social-icons a:hover {
+  color: #0077b5;
+}
+
+@media (min-width: 768px) {
+  .profile-header {
+    flex-direction: row;
+    text-align: left;
+  }
+  .profile-header .avatar {
+    margin-right: 2rem;
+  }
+  .profile-details {
+    align-items: flex-start;
+  }
+}
+


### PR DESCRIPTION
## Summary
- reorganize homepage markup into flex-based profile header to maintain alignment and prevent overlapping
- add responsive CSS and card-style wrapper for a more professional appearance

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6896d8d0742883288bd3dd3a02b17c48