### PR TITLE
Refresh gradient background and glass surfaces

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,5 +1,5 @@
 :root {
-  --background: #f7f8fb;
+  --background: #eef2fb;
   --surface: #ffffff;
   --text: #1f2933;
   --muted: #5f6c80;
@@ -7,6 +7,18 @@
   --accent-soft: rgba(37, 99, 235, 0.1);
   --border: #e5e7eb;
   --shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  --bg-linear: linear-gradient(130deg, #f4f6ff 0%, #f2fcff 50%, #fff5fb 100%);
+  --bg-radial-1: radial-gradient(80% 90% at 0% 0%, rgba(79, 70, 229, 0.16), transparent 70%);
+  --bg-radial-2: radial-gradient(70% 80% at 100% 10%, rgba(14, 165, 233, 0.16), transparent 72%);
+  --bg-radial-3: radial-gradient(85% 95% at 50% 100%, rgba(236, 72, 153, 0.12), transparent 75%);
+  --blob-gradient-a: radial-gradient(60% 60% at 10% 15%, rgba(79, 70, 229, 0.45), transparent 70%);
+  --blob-gradient-b: radial-gradient(55% 55% at 90% 85%, rgba(14, 165, 233, 0.4), transparent 70%);
+  --glass-surface: rgba(255, 255, 255, 0.62);
+  --glass-card-surface: rgba(255, 255, 255, 0.56);
+  --glass-border: rgba(255, 255, 255, 0.35);
+  --glass-border-strong: rgba(255, 255, 255, 0.6);
+  --glass-shadow: 0 30px 70px -35px rgba(15, 23, 42, 0.45);
+  --accent-underline: linear-gradient(90deg, rgba(37, 99, 235, 0.95), rgba(14, 165, 233, 0.8), rgba(236, 72, 153, 0.65));
 }
 
 * {
@@ -17,7 +29,12 @@ body {
   margin: 0;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.65;
-  background: var(--background);
+  background-color: var(--background);
+  background-image: var(--bg-radial-1), var(--bg-radial-2), var(--bg-radial-3), var(--bg-linear);
+  background-repeat: no-repeat;
+  background-position: 0% 0%, 100% 10%, 50% 100%, center;
+  background-size: 140% 140%, 130% 130%, 180% 180%, cover;
+  background-attachment: fixed;
   color: var(--text);
 }
 
@@ -175,14 +192,36 @@ img {
   padding: 3rem 0 4rem;
   display: grid;
   gap: 3rem;
+  position: relative;
+  z-index: 0;
+}
+
+.main-content::before {
+  content: '';
+  position: absolute;
+  inset: -12% -10% -18% -10%;
+  background-image: var(--blob-gradient-a), var(--blob-gradient-b);
+  filter: blur(120px);
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: -1;
 }
 
 .section {
-  background: var(--surface);
+  background: var(--glass-surface);
   padding: 2.5rem;
-  border-radius: 24px;
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
+  border-radius: 28px;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: blur(22px) saturate(160%);
+  -webkit-backdrop-filter: blur(22px) saturate(160%);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.section:hover {
+  border-color: var(--glass-border-strong);
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: 0 40px 85px -30px rgba(15, 23, 42, 0.55);
 }
 
 .section-title {
@@ -190,6 +229,20 @@ img {
   font-size: 1.65rem;
   font-weight: 700;
   letter-spacing: -0.02em;
+  position: relative;
+  padding-bottom: 0.75rem;
+}
+
+.section-title::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 3.5rem;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--accent-underline);
+  box-shadow: 0 0 16px rgba(37, 99, 235, 0.45);
 }
 
 .section p {
@@ -209,15 +262,19 @@ img {
 
 .card {
   padding: 1.5rem;
-  border-radius: 18px;
-  border: 1px solid var(--border);
-  background: #fbfdff;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border-radius: 20px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-card-surface);
+  box-shadow: 0 22px 55px -32px rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(18px) saturate(150%);
+  -webkit-backdrop-filter: blur(18px) saturate(150%);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
 .card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12);
+  transform: translateY(-6px);
+  box-shadow: 0 35px 80px -32px rgba(15, 23, 42, 0.6);
+  border-color: var(--glass-border-strong);
 }
 
 .card h3 {
@@ -239,12 +296,16 @@ img {
 }
 
 .chip {
-  background: var(--accent-soft);
+  background: linear-gradient(120deg, rgba(37, 99, 235, 0.2), rgba(14, 165, 233, 0.12));
   color: var(--accent);
   font-weight: 600;
-  padding: 0.5rem 0.85rem;
+  padding: 0.5rem 0.9rem;
   border-radius: 999px;
   font-size: 0.95rem;
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  box-shadow: 0 14px 30px -22px rgba(37, 99, 235, 0.75);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 .news-list {
@@ -256,10 +317,28 @@ img {
 }
 
 .news-item {
+  position: relative;
   display: grid;
-  gap: 0.35rem;
-  border-left: 3px solid var(--accent-soft);
-  padding-left: 1rem;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem 1rem 1.75rem;
+  border-radius: 18px;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.5);
+  box-shadow: 0 22px 55px -36px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+}
+
+.news-item::before {
+  content: '';
+  position: absolute;
+  left: 0.85rem;
+  top: 1rem;
+  bottom: 1rem;
+  width: 3px;
+  border-radius: 999px;
+  background: var(--accent-underline);
+  box-shadow: 0 0 12px rgba(37, 99, 235, 0.45);
 }
 
 .news-item time {
@@ -276,9 +355,18 @@ img {
   display: grid;
   gap: 0.5rem;
   padding: 1.5rem;
-  border: 1px solid var(--border);
-  border-radius: 18px;
-  background: var(--surface);
+  border: 1px solid var(--glass-border);
+  border-radius: 20px;
+  background: var(--glass-card-surface);
+  box-shadow: 0 24px 60px -34px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(18px) saturate(150%);
+  -webkit-backdrop-filter: blur(18px) saturate(150%);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.publication:hover {
+  border-color: var(--glass-border-strong);
+  box-shadow: 0 38px 90px -36px rgba(15, 23, 42, 0.6);
 }
 
 .publication__title {
@@ -306,9 +394,12 @@ img {
 .empty-state {
   margin: 0;
   padding: 1.5rem;
-  border-radius: 18px;
-  border: 1px dashed var(--border);
-  background: #f9fbff;
+  border-radius: 20px;
+  border: 1px dashed rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.45);
+  box-shadow: 0 26px 60px -40px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
   text-align: center;
   color: var(--muted);
 }


### PR DESCRIPTION
## Summary
- introduce gradient and glow tokens to drive the layered background refresh
- add blurred gradient overlays and glassmorphism styling to sections and titles
- align cards, publications, chips, and news items with the updated glass aesthetic

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc92cd85e08328a212d579de648aeb