### PR TITLE
Revamp hero header with gradients

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -7,6 +7,9 @@
   --accent-soft: rgba(37, 99, 235, 0.1);
   --border: #e5e7eb;
   --shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  --gradient-start: #1f1c2c;
+  --gradient-mid: #3a1c71;
+  --gradient-end: #6e48aa;
 }
 
 * {
@@ -43,9 +46,36 @@ img {
 }
 
 .site-header {
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-  box-shadow: var(--shadow);
+  position: relative;
+  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-mid) 45%, var(--gradient-end));
+  overflow: hidden;
+  color: #f8fbff;
+}
+
+.site-header::before,
+.site-header::after {
+  content: '';
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(60px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.site-header::before {
+  top: -25%;
+  left: -10%;
+  width: 520px;
+  height: 520px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0) 65%);
+}
+
+.site-header::after {
+  bottom: -35%;
+  right: -15%;
+  width: 640px;
+  height: 640px;
+  background: radial-gradient(circle, rgba(80, 181, 255, 0.45) 0%, rgba(80, 181, 255, 0) 70%);
 }
 
 .header-layout {
@@ -55,6 +85,8 @@ img {
   gap: 2.5rem;
   padding: 2.5rem 0 1.5rem;
   flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
 }
 
 .identity {
@@ -82,12 +114,12 @@ img {
 .identity__role {
   margin: 0.2rem 0 0.6rem;
   font-weight: 600;
-  color: var(--accent);
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .identity__tagline {
   margin: 0 0 0.8rem;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.72);
   max-width: 42rem;
 }
 
@@ -121,7 +153,7 @@ img {
   align-items: flex-end;
   text-align: right;
   font-size: 0.95rem;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .contact-block__links {
@@ -132,27 +164,32 @@ img {
 }
 
 .contact-block__links a {
-  color: var(--accent);
+  color: rgba(255, 255, 255, 0.85);
   font-weight: 600;
   border-bottom: 1px solid transparent;
 }
 
 .contact-block__links a:hover {
-  border-bottom-color: var(--accent);
+  border-bottom-color: rgba(255, 255, 255, 0.85);
 }
 
 .site-nav {
   display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;
-  padding: 0 0 1.5rem;
+  padding: 0.75rem 1.5rem 1.5rem;
   font-weight: 600;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border-radius: 999px;
 }
 
 .site-nav a {
   position: relative;
   padding-bottom: 0.4rem;
+  color: inherit;
 }
 
 .site-nav a::after {
@@ -168,7 +205,7 @@ img {
 
 .site-nav a:hover::after,
 .site-nav a:focus::after {
-  background: var(--accent);
+  background: rgba(255, 255, 255, 0.9);
 }
 
 .main-content {


### PR DESCRIPTION
## Summary
- add reusable gradient tokens to the global CSS palette
- restyle the site header with layered gradients and glowing orb effects
- update hero text and navigation styling for contrast over the new gradient hero

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc92cc80948328bc55535c4ad03fb1