### PR TITLE
Apply liquid-glass pastel redesign to homepage styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,31 +1,31 @@
 :root {
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --accent: #38bdf8;
-  --accent-strong: #22d3ee;
-  --accent-soft: rgba(56, 189, 248, 0.25);
-  --hero-gradient: linear-gradient(135deg, #0f172a 0%, #1e3a8a 45%, #0ea5e9 100%);
-  --hero-orb-1: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.5) 0%, rgba(56, 189, 248, 0) 60%);
-  --hero-orb-2: radial-gradient(circle at 85% 0%, rgba(139, 92, 246, 0.45) 0%, rgba(139, 92, 246, 0) 65%);
-  --body-gradient: radial-gradient(120% 120% at 10% 0%, rgba(56, 189, 248, 0.2) 0%, rgba(4, 10, 26, 0) 52%),
-    radial-gradient(110% 110% at 90% 0%, rgba(94, 234, 212, 0.18) 0%, rgba(5, 11, 28, 0) 55%),
-    linear-gradient(180deg, #020617 0%, #050b1c 48%, #02030a 100%);
-  --text: rgba(232, 240, 255, 0.92);
-  --muted: rgba(198, 208, 255, 0.74);
-  --heading: #f8f9ff;
-  --hero-muted: rgba(214, 225, 255, 0.78);
-  --glass-bg: rgba(12, 20, 40, 0.76);
-  --glass-border: rgba(148, 191, 255, 0.25);
-  --glass-shadow: 0 35px 80px rgba(3, 7, 20, 0.55);
-  --card-bg: linear-gradient(145deg, rgba(18, 32, 72, 0.95), rgba(14, 24, 54, 0.6));
-  --card-border: rgba(148, 191, 255, 0.22);
-  --card-shadow: 0 24px 60px rgba(5, 10, 30, 0.45);
-  --chip-bg: rgba(56, 189, 248, 0.22);
-  --chip-border: rgba(148, 191, 255, 0.5);
-  --chip-text: rgba(235, 242, 255, 0.92);
-  --news-border: rgba(56, 189, 248, 0.65);
-  --publication-bg: linear-gradient(150deg, rgba(16, 28, 62, 0.92), rgba(14, 24, 54, 0.62));
-  --publication-border: rgba(147, 197, 253, 0.24);
-  --shadow-strong: 0 45px 90px rgba(2, 6, 20, 0.65);
+  --accent: #6d8cff;
+  --accent-strong: #7cb8ff;
+  --accent-soft: rgba(124, 184, 255, 0.22);
+  --hero-gradient: linear-gradient(140deg, rgba(255, 255, 255, 0.82) 0%, rgba(219, 240, 255, 0.8) 38%, rgba(227, 220, 255, 0.78) 100%);
+  --hero-orb-1: radial-gradient(circle at 20% 20%, rgba(174, 223, 255, 0.8) 0%, rgba(174, 223, 255, 0) 66%);
+  --hero-orb-2: radial-gradient(circle at 85% 0%, rgba(209, 194, 255, 0.66) 0%, rgba(209, 194, 255, 0) 67%);
+  --body-gradient: radial-gradient(130% 130% at 12% 0%, rgba(214, 241, 255, 0.95) 0%, rgba(255, 255, 255, 0.55) 52%),
+    radial-gradient(115% 115% at 90% -8%, rgba(230, 219, 255, 0.85) 0%, rgba(250, 250, 255, 0.5) 55%),
+    linear-gradient(180deg, #f7fbff 0%, #f5f8ff 46%, #f8f6ff 100%);
+  --text: rgba(54, 70, 112, 0.94);
+  --muted: rgba(97, 114, 154, 0.78);
+  --heading: #2f3e6f;
+  --hero-muted: rgba(77, 97, 146, 0.86);
+  --glass-bg: linear-gradient(145deg, rgba(255, 255, 255, 0.6), rgba(241, 248, 255, 0.44));
+  --glass-border: rgba(151, 188, 255, 0.44);
+  --glass-shadow: 0 25px 65px rgba(134, 166, 224, 0.24);
+  --card-bg: linear-gradient(150deg, rgba(255, 255, 255, 0.72), rgba(236, 246, 255, 0.46));
+  --card-border: rgba(147, 181, 255, 0.34);
+  --card-shadow: 0 18px 42px rgba(131, 162, 219, 0.2);
+  --chip-bg: rgba(202, 228, 255, 0.56);
+  --chip-border: rgba(157, 193, 255, 0.58);
+  --chip-text: rgba(67, 86, 138, 0.95);
+  --news-border: rgba(130, 174, 255, 0.8);
+  --publication-bg: linear-gradient(160deg, rgba(255, 255, 255, 0.74), rgba(237, 244, 255, 0.45));
+  --publication-border: rgba(153, 189, 255, 0.36);
+  --shadow-strong: 0 35px 80px rgba(142, 173, 227, 0.28);
 }
 
 * {
@@ -33,8 +33,8 @@
 }
 
 ::selection {
-  background: rgba(56, 189, 248, 0.35);
-  color: #fff;
+  background: rgba(121, 176, 255, 0.32);
+  color: #2f3e6f;
 }
 
 body {
@@ -46,9 +46,9 @@ body {
   color: var(--text);
   overflow-x: hidden;
   position: relative;
-  background-size: 135% 135%, 155% 155%, 100% 100%;
+  background-size: 130% 130%, 150% 150%, 100% 100%;
   background-position: 0% 0%, 100% 0%, center;
-  animation: auroraFlow 22s ease-in-out infinite;
+  animation: auroraFlow 20s ease-in-out infinite;
 }
 
 a {
@@ -60,7 +60,7 @@ a {
 a:hover,
 a:focus {
   color: var(--accent-strong);
-  text-shadow: 0 0 12px rgba(34, 211, 238, 0.45);
+  text-shadow: 0 0 10px rgba(124, 184, 255, 0.35);
 }
 
 img {
@@ -150,9 +150,9 @@ img {
   border-radius: 32px;
   padding: 6px;
   border: 2px solid transparent;
-  background: linear-gradient(#131b3b, #131b3b) padding-box,
-    linear-gradient(135deg, rgba(139, 92, 246, 0.95), rgba(34, 211, 238, 0.9)) border-box;
-  box-shadow: 0 24px 45px rgba(5, 10, 30, 0.55), 0 0 60px rgba(88, 165, 255, 0.45);
+  background: linear-gradient(#f4f8ff, #f4f8ff) padding-box,
+    linear-gradient(135deg, rgba(158, 193, 255, 0.95), rgba(199, 182, 255, 0.92)) border-box;
+  box-shadow: 0 18px 36px rgba(122, 154, 218, 0.36), 0 0 50px rgba(180, 212, 255, 0.46);
   object-fit: cover;
   object-position: center;
   display: block;
@@ -163,7 +163,7 @@ img {
 .identity__avatar:hover,
 .identity__avatar:focus {
   transform: translateY(-10px) scale(1.02);
-  box-shadow: 0 28px 65px rgba(5, 10, 30, 0.6), 0 0 85px rgba(88, 165, 255, 0.55);
+  box-shadow: 0 24px 60px rgba(122, 154, 218, 0.38), 0 0 70px rgba(180, 212, 255, 0.62);
   filter: saturate(1.05);
 }
 
@@ -182,7 +182,7 @@ img {
 .identity__role {
   margin: 0.35rem 0 0.75rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(79, 100, 153, 0.86);
   text-transform: uppercase;
   letter-spacing: 0.22em;
 }
@@ -208,10 +208,10 @@ img {
   gap: 0.4rem;
   padding: 0.45rem 0.95rem;
   border-radius: 999px;
-  background: rgba(13, 25, 66, 0.55);
-  border: 1px solid rgba(170, 196, 255, 0.35);
+  background: rgba(240, 248, 255, 0.66);
+  border: 1px solid rgba(166, 196, 255, 0.42);
   color: var(--heading);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
   transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
 }
 
@@ -221,8 +221,8 @@ img {
 
 .identity__affiliations li:hover {
   transform: translateY(-2px);
-  background: rgba(26, 46, 102, 0.8);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+  background: rgba(230, 241, 255, 0.84);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .contact-block {
@@ -272,9 +272,9 @@ img {
   gap: 0.75rem;
   padding: 0.6rem 1.1rem;
   border-radius: 16px;
-  border: 1px solid rgba(173, 196, 255, 0.2);
-  background: rgba(13, 25, 66, 0.55);
-  color: rgba(236, 242, 255, 0.95);
+  border: 1px solid rgba(167, 196, 255, 0.44);
+  background: rgba(244, 249, 255, 0.72);
+  color: rgba(72, 95, 146, 0.95);
   font-family: inherit;
   font-size: 0.95rem;
   font-weight: 600;
@@ -291,8 +291,8 @@ img {
 .site-nav__toggle:focus-visible,
 .site-nav__toggle:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 35px rgba(10, 18, 46, 0.45);
-  border-color: rgba(173, 196, 255, 0.45);
+  box-shadow: 0 16px 32px rgba(130, 160, 216, 0.3);
+  border-color: rgba(145, 182, 255, 0.62);
 }
 
 .site-nav__toggle-box {
@@ -307,7 +307,7 @@ img {
   display: block;
   height: 2px;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(139, 92, 246, 0.9), rgba(34, 211, 238, 0.9));
+  background: linear-gradient(90deg, rgba(152, 174, 255, 0.95), rgba(156, 214, 255, 0.95));
 }
 
 .site-nav {
@@ -319,11 +319,11 @@ img {
   padding: 0.85rem 1.85rem;
   margin-bottom: 0.5rem;
   border-radius: 999px;
-  background: rgba(11, 22, 58, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  backdrop-filter: blur(24px) saturate(140%);
-  box-shadow: 0 22px 45px rgba(10, 18, 46, 0.45);
-  color: rgba(230, 238, 255, 0.9);
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.65), rgba(233, 245, 255, 0.46));
+  border: 1px solid rgba(159, 192, 255, 0.4);
+  backdrop-filter: blur(26px) saturate(130%);
+  box-shadow: 0 16px 38px rgba(132, 164, 222, 0.28);
+  color: rgba(67, 88, 140, 0.95);
 }
 
 .site-nav a {
@@ -341,7 +341,7 @@ img {
   width: 100%;
   height: 2px;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(139, 92, 246, 0.9), rgba(34, 211, 238, 0.9));
+  background: linear-gradient(90deg, rgba(152, 174, 255, 0.95), rgba(156, 214, 255, 0.95));
   transform: scaleX(0);
   transform-origin: left;
   transition: transform 0.25s ease;
@@ -395,8 +395,9 @@ img {
   padding: 2.75rem;
   box-shadow: var(--glass-shadow);
   backdrop-filter: blur(26px) saturate(140%);
-  color: rgba(236, 242, 255, 0.92);
+  color: rgba(72, 92, 144, 0.94);
   overflow: hidden;
+  animation: liquidLift 10s ease-in-out infinite;
 }
 
 .section::before {
@@ -404,8 +405,18 @@ img {
   position: absolute;
   inset: -30% 60% auto -20%;
   height: 160%;
-  background: linear-gradient(140deg, rgba(139, 92, 246, 0.18), rgba(34, 211, 238, 0));
-  opacity: 0.4;
+  background: linear-gradient(140deg, rgba(188, 206, 255, 0.42), rgba(168, 228, 255, 0));
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.section::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(115deg, rgba(255, 255, 255, 0.34) 0%, rgba(255, 255, 255, 0.06) 38%, rgba(167, 209, 255, 0.12) 62%, rgba(255, 255, 255, 0.34) 100%);
+  transform: translateX(-120%);
+  animation: glassShimmer 12s ease-in-out infinite;
   pointer-events: none;
 }
 
@@ -443,13 +454,13 @@ img {
   font-size: 0.85rem;
   letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: rgba(148, 191, 255, 0.8);
+  color: rgba(124, 156, 221, 0.84);
   font-weight: 600;
 }
 
 .section-subtitle {
   margin: 0;
-  color: rgba(210, 225, 255, 0.78);
+  color: rgba(96, 116, 168, 0.82);
   max-width: 640px;
 }
 
@@ -470,10 +481,10 @@ img {
 .highlight-list li {
   padding: 0.85rem 1rem;
   border-radius: 16px;
-  border: 1px solid rgba(148, 191, 255, 0.2);
-  background: rgba(12, 22, 50, 0.55);
-  color: rgba(225, 235, 255, 0.9);
-  box-shadow: inset 0 0 24px rgba(8, 18, 40, 0.35);
+  border: 1px solid rgba(157, 190, 255, 0.3);
+  background: rgba(239, 248, 255, 0.62);
+  color: rgba(76, 98, 150, 0.9);
+  box-shadow: inset 0 0 18px rgba(192, 219, 255, 0.3);
 }
 
 .stat-grid {
@@ -507,8 +518,8 @@ img {
   padding: 1.6rem;
   border-radius: 22px;
   border: 1px solid rgba(148, 191, 255, 0.25);
-  background: rgba(10, 20, 46, 0.6);
-  box-shadow: inset 0 0 30px rgba(5, 12, 32, 0.4);
+  background: rgba(241, 248, 255, 0.58);
+  box-shadow: inset 0 0 24px rgba(193, 221, 255, 0.32);
 }
 
 .detail-card h3 {
@@ -526,7 +537,7 @@ img {
 .section p {
   margin-top: 0;
   margin-bottom: 1.1rem;
-  color: rgba(226, 234, 255, 0.88);
+  color: rgba(80, 100, 151, 0.9);
 }
 
 .section p:last-child {
@@ -550,8 +561,8 @@ img {
 
 .card:hover {
   transform: translateY(-6px) scale(1.01);
-  box-shadow: 0 30px 70px rgba(5, 10, 35, 0.5);
-  border-color: rgba(170, 196, 255, 0.45);
+  box-shadow: 0 24px 55px rgba(128, 157, 219, 0.3);
+  border-color: rgba(155, 189, 255, 0.6);
 }
 
 .card h3 {
@@ -564,7 +575,7 @@ img {
 .card ul {
   margin: 0;
   padding-left: 1rem;
-  color: rgba(214, 224, 255, 0.85);
+  color: rgba(90, 111, 165, 0.85);
 }
 
 .card ul li + li {
@@ -586,7 +597,7 @@ img {
   border-radius: 999px;
   font-size: 0.98rem;
   letter-spacing: 0.01em;
-  box-shadow: inset 0 0 18px rgba(10, 22, 54, 0.4);
+  box-shadow: inset 0 0 14px rgba(197, 222, 255, 0.6);
 }
 
 .news-list {
@@ -602,13 +613,13 @@ img {
   gap: 0.45rem;
   border-left: 3px solid var(--news-border);
   padding-left: 1.2rem;
-  background: linear-gradient(120deg, rgba(16, 33, 74, 0.45), rgba(19, 28, 63, 0));
+  background: linear-gradient(120deg, rgba(238, 247, 255, 0.8), rgba(239, 245, 255, 0.1));
   border-radius: 8px;
 }
 
 .news-item time {
   font-weight: 600;
-  color: rgba(129, 178, 255, 0.95);
+  color: rgba(109, 147, 224, 0.95);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -640,7 +651,7 @@ img {
 }
 
 .publication__meta {
-  color: rgba(207, 219, 255, 0.82);
+  color: rgba(98, 118, 170, 0.82);
   font-size: 0.98rem;
 }
 
@@ -652,19 +663,19 @@ img {
 
 .publication__links a {
   font-weight: 600;
-  color: rgba(139, 215, 255, 0.95);
+  color: rgba(111, 161, 236, 0.95);
   text-decoration: underline;
-  text-decoration-color: rgba(139, 215, 255, 0.4);
+  text-decoration-color: rgba(111, 161, 236, 0.45);
 }
 
 .empty-state {
   margin: 0;
   padding: 1.8rem;
   border-radius: 20px;
-  border: 1px dashed rgba(173, 209, 255, 0.35);
-  background: rgba(17, 31, 68, 0.35);
+  border: 1px dashed rgba(159, 191, 255, 0.5);
+  background: rgba(239, 247, 255, 0.55);
   text-align: center;
-  color: rgba(205, 217, 255, 0.78);
+  color: rgba(95, 117, 170, 0.78);
 }
 
 .service-columns {
@@ -682,12 +693,12 @@ img {
 .service-columns ul {
   margin: 0;
   padding-left: 1rem;
-  color: rgba(214, 224, 255, 0.85);
+  color: rgba(90, 111, 165, 0.85);
 }
 
 .site-footer {
   background: transparent;
-  color: rgba(184, 199, 255, 0.6);
+  color: rgba(108, 128, 178, 0.72);
   padding: 2.5rem 0 3.5rem;
   text-align: center;
   font-size: 0.95rem;
@@ -919,6 +930,31 @@ img {
   }
   50% {
     transform: translateY(-6px);
+  }
+}
+
+@keyframes glassShimmer {
+  0%,
+  100% {
+    transform: translateX(-120%);
+    opacity: 0;
+  }
+  30% {
+    opacity: 0.45;
+  }
+  55% {
+    transform: translateX(120%);
+    opacity: 0.25;
+  }
+}
+
+@keyframes liquidLift {
+  0%,
+  100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-4px);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Transform the site's visual language to a liquid glass aesthetic using a bright pastel palette (white, ice blue, light purple) and subtle motion so the homepage feels frosted, airy, and animated.

### Description
- Replaced core theme tokens and gradients in `assets/css/main.css` to a pastel liquid-glass palette and adjusted text/muted/heading colors for improved contrast on the new background.  
- Restyled hero/avatar, affiliation chips, nav toggle and nav shell, cards, news/publication blocks, empty states, and footer to use translucent glass backgrounds, softer borders, and quieter shadows.  
- Added animated glass effects including a shimmering overlay on sections and a gentle `liquidLift` floating animation to make panels feel fluid.  
- Tweaked global selection, background sizing/timing, and small shadow/hover refinements to match the new frosted theme.

### Testing
- Ran `bundle exec jekyll build`, which failed because the `jekyll` executable is not installed in the environment.  
- Ran `bundle install`, which failed due to external gem fetch errors (`rubygems` returned HTTP 403) in this environment.  
- Attempted a Playwright screenshot of a locally served site at `http://127.0.0.1:4000`, which failed because no local server could be started without Jekyll dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d04e9c9f083288018a3cf20cdc98d)