### PR TITLE
Homepage redesign: Academic Minimal + AI Modern (tokens, hero, sticky nav)

### DIFF
--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -1,0 +1,31 @@
+# Design Notes
+
+## Tokens
+- Global design tokens live in `assets/css/main.css` under the top-level `:root` block.
+- Core palette variables are:
+  - `--primary`, `--accent`, `--highlight`
+  - `--background`, `--background-alt`
+  - `--text-primary`, `--text-secondary`, `--muted`, `--border`
+- Shared spacing and motion tokens are also in `:root` (`--section-pad`, `--nav-height`, `--motion-fast`, `--motion-med`).
+
+## Updated Components
+- **Hero/Header** (`_layouts/homepage.html` + `assets/css/main.css`)
+  - Upgraded to desktop two-column structure with portrait/text cluster + contact column.
+  - Added CTA button row: Publications, Research, Contact.
+- **Navigation**
+  - Made navigation bar sticky with light blur/shadow treatment.
+  - Added section `scroll-margin-top` to keep anchor targets visible below sticky nav.
+- **Sections**
+  - Introduced alternating section backgrounds (white / background-alt).
+  - Added consistent vertical rhythm and left accent rule for section titles.
+- **Cards / Tiles**
+  - Standardized stats, research cards, publication/news cards with shared borders, radius, and hover lift.
+  - Current research cards use same hover elevation pattern (`translateY(-4px)` + softer shadow).
+- **Interactions & Accessibility**
+  - Added consistent link underline transitions and visible focus rings.
+  - Kept reduced-motion support for users with `prefers-reduced-motion`.
+
+## Tuning Later
+- **Palette:** adjust only root variables to recolor globally.
+- **Spacing scale:** tweak `--section-pad`, `--content-width`, and breakpoint blocks.
+- **Motion:** reduce or increase animation feel by editing `--motion-fast` / `--motion-med` and hover shadow tokens.

--- a/_includes/publications.md
+++ b/_includes/publications.md
@@ -1,4 +1,4 @@
-<section id="publications" class="section glass">
+<section id="publications" class="section">
   <div class="section-header">
     <p class="section-kicker">Scholarship</p>
     <h2 class="section-title">Selected Publications</h2>
@@ -8,7 +8,7 @@
   {% if publications.size > 0 %}
   <div class="publication-list">
     {% for paper in publications %}
-    <article class="publication glass">
+    <article class="publication">
       <h3 class="publication__title">
         {% if paper.pdf %}
         <a href="{{ paper.pdf }}">{{ paper.title }}</a>

--- a/_includes/services.md
+++ b/_includes/services.md
@@ -1,4 +1,4 @@
-<section id="service" class="section glass">
+<section id="service" class="section">
   <div class="section-header">
     <p class="section-kicker">Leadership</p>
     <h2 class="section-title">Service &amp; Recognition</h2>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -36,6 +36,11 @@
             {% if site.tagline %}
             <p class="identity__tagline">{{ site.tagline }}</p>
             {% endif %}
+            <div class="hero-ctas" aria-label="Primary actions">
+              <a class="btn btn--primary" href="#publications">Publications</a>
+              <a class="btn btn--outline" href="#initiatives">Research</a>
+              <a class="btn btn--outline" href="#service">Contact</a>
+            </div>
             {% if site.affiliations %}
             <ul class="identity__affiliations">
               {% for affiliation in site.affiliations %}
@@ -68,7 +73,7 @@
         </div>
       </div>
       <div class="container site-nav-wrapper">
-        <button class="site-nav__toggle glass glass--light" type="button" aria-expanded="false" aria-controls="site-navigation">
+        <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="site-navigation">
           <span class="site-nav__toggle-box" aria-hidden="true">
             <span class="site-nav__toggle-line"></span>
             <span class="site-nav__toggle-line"></span>
@@ -76,7 +81,7 @@
           </span>
           <span class="site-nav__toggle-label">Menu</span>
         </button>
-        <nav id="site-navigation" class="site-nav glass" aria-label="Section navigation">
+        <nav id="site-navigation" class="site-nav" aria-label="Section navigation">
           <a href="#about">About</a>
           <a href="#snapshot">Snapshot</a>
           <a href="#laboratories">Laboratories</a>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,68 +1,59 @@
 @import url('glass.css');
 
 :root {
+  --primary: #0B3D91;
+  --accent: #00A8E8;
+  --highlight: #F59E0B;
+  --background: #FAFBFC;
+  --background-alt: #F1F5F9;
+  --text-primary: #0F172A;
+  --text-secondary: #475569;
+  --muted: #94A3B8;
+  --border: #E2E8F0;
+
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --accent: #6d8cff;
-  --accent-strong: #7cb8ff;
-  --accent-soft: rgba(124, 184, 255, 0.22);
-  --hero-gradient: linear-gradient(140deg, rgba(255, 255, 255, 0.82) 0%, rgba(219, 240, 255, 0.8) 38%, rgba(227, 220, 255, 0.78) 100%);
-  --hero-orb-1: radial-gradient(circle at 20% 20%, rgba(174, 223, 255, 0.8) 0%, rgba(174, 223, 255, 0) 66%);
-  --hero-orb-2: radial-gradient(circle at 85% 0%, rgba(209, 194, 255, 0.66) 0%, rgba(209, 194, 255, 0) 67%);
-  --body-gradient: radial-gradient(130% 130% at 12% 0%, rgba(214, 241, 255, 0.9) 0%, rgba(243, 247, 255, 0.7) 52%),
-    radial-gradient(115% 115% at 90% -8%, rgba(230, 219, 255, 0.7) 0%, rgba(243, 240, 255, 0.62) 55%),
-    linear-gradient(175deg, #eef4ff 0%, #e8f1ff 45%, #f0ecff 100%);
-  --text: rgba(44, 58, 92, 0.96);
-  --muted: rgba(74, 90, 126, 0.78);
-  --heading: #24345f;
-  --hero-muted: rgba(66, 84, 125, 0.88);
-  --glass-bg: linear-gradient(145deg, rgba(255, 255, 255, 0.6), rgba(241, 248, 255, 0.44));
-  --glass-border: rgba(151, 188, 255, 0.44);
-  --glass-shadow: 0 25px 65px rgba(134, 166, 224, 0.24);
-  --card-bg: linear-gradient(150deg, rgba(255, 255, 255, 0.72), rgba(236, 246, 255, 0.46));
-  --card-border: rgba(147, 181, 255, 0.34);
-  --card-shadow: 0 18px 42px rgba(131, 162, 219, 0.2);
-  --chip-bg: rgba(202, 228, 255, 0.56);
-  --chip-border: rgba(157, 193, 255, 0.58);
-  --chip-text: rgba(58, 76, 119, 0.94);
-  --news-border: rgba(130, 174, 255, 0.8);
-  --publication-bg: linear-gradient(160deg, rgba(255, 255, 255, 0.74), rgba(237, 244, 255, 0.45));
-  --publication-border: rgba(153, 189, 255, 0.36);
-  --shadow-strong: 0 35px 80px rgba(142, 173, 227, 0.28);
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+  --content-width: 1120px;
+  --section-pad: clamp(2.5rem, 4vw, 4rem);
+  --nav-height: 76px;
+  --shadow-sm: 0 6px 20px rgba(15, 23, 42, 0.06);
+  --shadow-md: 0 12px 28px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 20px 42px rgba(15, 23, 42, 0.12);
+  --motion-fast: 180ms ease;
+  --motion-med: 210ms ease;
 }
 
-* {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
-::selection {
-  background: rgba(121, 176, 255, 0.32);
-  color: #2f3e6f;
+html {
+  scroll-behavior: smooth;
 }
 
 body {
   margin: 0;
-  min-height: 100vh;
   font-family: var(--font-body);
+  font-weight: 400;
   line-height: 1.7;
-  background: var(--body-gradient);
-  color: var(--text);
-  overflow-x: hidden;
-  position: relative;
-  background-size: 130% 130%, 150% 150%, 100% 100%;
-  background-position: 0% 0%, 100% 0%, center;
-  animation: auroraFlow 20s ease-in-out infinite;
+  color: var(--text-primary);
+  background: var(--background);
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-  transition: color 0.25s ease, text-shadow 0.25s ease;
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  background-image: radial-gradient(var(--border) 0.7px, transparent 0.7px);
+  background-size: 20px 20px;
+  z-index: -1;
 }
 
-a:hover,
-a:focus {
-  color: var(--accent-strong);
-  text-shadow: 0 0 10px rgba(124, 184, 255, 0.35);
+::selection {
+  background: rgba(0, 168, 232, 0.2);
+  color: var(--text-primary);
 }
 
 img {
@@ -72,185 +63,155 @@ img {
 }
 
 .container {
-  width: min(1120px, calc(100% - 3rem));
+  width: min(var(--content-width), calc(100% - 2.25rem));
   margin: 0 auto;
-  position: relative;
-  z-index: 1;
+}
+
+a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-decoration-color: rgba(11, 61, 145, 0.3);
+  text-underline-offset: 0.14em;
+  transition: color var(--motion-fast), text-decoration-color var(--motion-fast);
+}
+
+a:hover {
+  color: var(--accent);
+  text-decoration-color: rgba(0, 168, 232, 0.7);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 3px solid rgba(0, 168, 232, 0.45);
+  outline-offset: 3px;
+  border-radius: 6px;
 }
 
 .site-header {
-  position: relative;
-  overflow: hidden;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.74), rgba(235, 246, 255, 0.58));
-  border: 1px solid rgba(158, 186, 236, 0.42);
-  box-shadow: 0 24px 55px rgba(122, 151, 207, 0.22);
-  color: var(--heading);
-  padding-bottom: 2rem;
-  margin: 1rem auto 0;
-  border-radius: 28px;
-  width: min(1160px, calc(100% - 2rem));
-  backdrop-filter: blur(20px) saturate(130%);
-  -webkit-backdrop-filter: blur(20px) saturate(130%);
-}
-
-.site-header::before,
-.site-header::after {
-  content: '';
-  position: absolute;
-  inset: auto;
-  width: 80vmax;
-  height: 80vmax;
-  pointer-events: none;
-  opacity: 0.42;
-  filter: blur(0.4px);
-  animation-duration: 26s;
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
-  will-change: transform;
-}
-
-.site-header::before {
-  animation-name: orbDriftLeft;
-  top: -30vmax;
-  left: -10vmax;
-  background: var(--hero-orb-1);
-}
-
-.site-header::after {
-  animation-name: orbDriftRight;
-  top: -22vmax;
-  right: -30vmax;
-  background: var(--hero-orb-2);
-}
-
-.site-header::before {
-  animation-delay: -6s;
-}
-
-.site-header::after {
-  animation-delay: -13s;
-}
-
-.site-header > .container {
-  position: relative;
-  z-index: 2;
+  background: var(--background);
+  border-bottom: 1px solid var(--border);
 }
 
 .header-layout {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(240px, 0.7fr);
+  gap: 2rem;
   align-items: center;
-  justify-content: space-between;
-  gap: 3rem;
-  padding: 3.5rem 0 2.25rem;
-  flex-wrap: wrap;
+  padding: 2.5rem 0 1.5rem;
 }
 
 .identity {
-  display: flex;
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 1.5rem;
   align-items: center;
-  gap: 2.25rem;
 }
 
 .identity__avatar {
-  width: 192px;
-  height: 192px;
-  border-radius: 32px;
-  padding: 6px;
-  border: 2px solid transparent;
-  background: linear-gradient(#f4f8ff, #f4f8ff) padding-box,
-    linear-gradient(135deg, rgba(158, 193, 255, 0.95), rgba(199, 182, 255, 0.92)) border-box;
-  box-shadow: 0 18px 36px rgba(122, 154, 218, 0.36), 0 0 50px rgba(180, 212, 255, 0.46);
+  width: 180px;
+  height: 180px;
   object-fit: cover;
-  object-position: center;
-  display: block;
-  transition: transform 0.5s ease, box-shadow 0.5s ease, filter 0.5s ease;
-  animation: float 9s ease-in-out infinite;
-}
-
-.identity__avatar:hover,
-.identity__avatar:focus {
-  transform: translateY(-10px) scale(1.02);
-  box-shadow: 0 24px 60px rgba(122, 154, 218, 0.38), 0 0 70px rgba(180, 212, 255, 0.62);
-  filter: saturate(1.05);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
 }
 
 .identity__text {
-  max-width: 560px;
-}
-
-
-.identity__text.glass {
-  padding: 1.4rem 1.6rem;
-  border-radius: 24px;
+  max-width: 62ch;
 }
 
 .identity__name {
   margin: 0;
-  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  font-size: clamp(2rem, 3.4vw, 2.8rem);
   font-weight: 700;
-  letter-spacing: -0.03em;
-  color: var(--heading);
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
 }
 
 .identity__role {
-  margin: 0.35rem 0 0.75rem;
+  margin: 0.55rem 0 0.2rem;
+  color: var(--primary);
+  font-size: 0.86rem;
   font-weight: 600;
-  color: rgba(58, 76, 119, 0.9);
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  letter-spacing: 0.22em;
 }
 
 .identity__tagline {
-  margin: 0 0 1rem;
-  color: var(--hero-muted);
-  font-size: 1.05rem;
+  margin: 0 0 0.9rem;
+  color: var(--text-secondary);
+  font-size: 1.02rem;
 }
 
 .identity__affiliations {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem 1rem;
+  list-style: none;
   padding: 0;
   margin: 0;
-  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
 }
 
 .identity__affiliations li {
+  border: 1px solid var(--border);
+  background: #fff;
+  border-radius: 999px;
+  padding: 0.42rem 0.78rem;
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+}
+
+.hero-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
+.btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.45rem 0.95rem;
-  border-radius: 999px;
-  background: rgba(237, 247, 255, 0.2);
-  border: 1px solid rgba(166, 196, 255, 0.42);
-  color: var(--heading);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+  justify-content: center;
+  padding: 0.56rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: all var(--motion-med);
 }
 
-.identity__affiliations li a {
-  color: inherit;
+.btn--primary {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
 }
 
-.identity__affiliations li:hover {
-  transform: translateY(-2px);
-  background: rgba(230, 241, 255, 0.84);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.75);
+.btn--primary:hover {
+  background: #0a3278;
+  color: #fff;
+}
+
+.btn--outline {
+  background: #fff;
+  color: var(--primary);
+  border-color: var(--border);
+}
+
+.btn--outline:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .contact-block {
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-  align-items: flex-end;
   text-align: right;
-  font-size: 0.98rem;
-  color: var(--hero-muted);
+  color: var(--text-secondary);
+  display: grid;
+  gap: 0.45rem;
+  justify-items: end;
 }
 
-.contact-block__item {
-  margin: 0;
-}
+.contact-block__item { margin: 0; }
 
 .contact-block__links {
   display: flex;
@@ -260,1120 +221,383 @@ img {
 }
 
 .contact-block__links a {
-  color: var(--heading);
+  text-decoration: none;
   font-weight: 600;
-  padding-bottom: 0.2rem;
-  border-bottom: 1px solid transparent;
+  color: var(--primary);
 }
-
-.contact-block__links a:hover,
-.contact-block__links a:focus {
-  border-bottom-color: rgba(96, 124, 184, 0.55);
-}
-
 
 .site-nav-wrapper {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  min-height: var(--nav-height);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
+  margin-bottom: 1rem;
+  padding: 0.6rem 0;
+  background: rgba(250, 251, 252, 0.92);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
 }
 
 .site-nav__toggle {
   display: none;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.6rem 1.1rem;
-  border-radius: 16px;
-  border: 1px solid rgba(167, 196, 255, 0.44);
-  background: rgba(255, 255, 255, 0.62);
-  color: rgba(47, 65, 108, 0.95);
-  font-family: inherit;
-  font-size: 0.95rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  cursor: pointer;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-.site-nav__toggle-label {
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-}
-
-.site-nav__toggle:focus-visible,
-.site-nav__toggle:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(130, 160, 216, 0.3);
-  border-color: rgba(145, 182, 255, 0.62);
-}
 
 .site-nav__toggle-box {
-  position: relative;
-  width: 22px;
-  height: 16px;
+  width: 18px;
+  height: 14px;
   display: grid;
-  align-items: center;
+  gap: 3px;
 }
 
 .site-nav__toggle-line {
-  display: block;
   height: 2px;
+  background: var(--primary);
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(152, 174, 255, 0.95), rgba(156, 214, 255, 0.95));
+}
+
+.site-nav__toggle-label {
+  letter-spacing: 0.02em;
 }
 
 .site-nav {
   display: flex;
+  gap: 1.1rem;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
-  gap: 1.75rem;
-  padding: 0.85rem 1.85rem;
-  margin-bottom: 0.5rem;
-  border-radius: 999px;
-  background: transparent;
-  border: none;
-  backdrop-filter: none;
-  box-shadow: none;
-  color: rgba(47, 65, 108, 0.96);
 }
 
 .site-nav a {
-  position: relative;
-  padding-bottom: 0.35rem;
+  color: var(--text-secondary);
+  text-decoration: none;
   font-weight: 600;
-  letter-spacing: 0.03em;
+  font-size: 0.94rem;
+  padding: 0.3rem 0.1rem;
+  border-bottom: 2px solid transparent;
+  transition: color var(--motion-fast), border-color var(--motion-fast);
 }
 
-.site-nav a::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 2px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(152, 174, 255, 0.95), rgba(156, 214, 255, 0.95));
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.25s ease;
-}
-
-.site-nav a:hover::after,
-.site-nav a:focus::after {
-  transform: scaleX(1);
+.site-nav a:hover,
+.site-nav a:focus,
+.site-nav a.is-active {
+  color: var(--primary);
+  border-color: var(--accent);
 }
 
 .main-content {
-  position: relative;
-  padding: 3.6rem 0 6rem;
   display: grid;
-  gap: 3.5rem;
-  z-index: 1;
-}
-
-.main-content::before,
-.main-content::after {
-  content: '';
-  position: absolute;
-  z-index: 0;
-  filter: blur(0.5px);
-  opacity: 0.65;
-}
-
-.main-content::before {
-  top: -8rem;
-  left: -12rem;
-  width: 36rem;
-  height: 36rem;
-  background: radial-gradient(circle at center, rgba(139, 92, 246, 0.25) 0%, rgba(139, 92, 246, 0) 70%);
-  animation: pulseGlow 14s ease-in-out infinite;
-}
-
-.main-content::after {
-  bottom: -10rem;
-  right: -14rem;
-  width: 40rem;
-  height: 40rem;
-  background: radial-gradient(circle at center, rgba(34, 211, 238, 0.22) 0%, rgba(34, 211, 238, 0) 70%);
-  animation: pulseGlow 18s ease-in-out infinite reverse;
+  gap: 0;
+  padding-bottom: 3.5rem;
 }
 
 .section {
-  position: relative;
-  background: rgba(255, 255, 255, 0.56);
-  border: 1px solid var(--glass-border);
-  border-radius: 28px;
-  padding: 2.75rem;
-  box-shadow: var(--glass-shadow);
-  backdrop-filter: blur(26px) saturate(140%);
-  color: var(--text);
-  overflow: hidden;
-  animation: liquidLift 10s ease-in-out infinite;
+  padding: var(--section-pad);
+  border-bottom: 1px solid var(--border);
 }
 
-.section::before {
-  content: '';
-  position: absolute;
-  inset: -30% 60% auto -20%;
-  height: 160%;
-  background: linear-gradient(140deg, rgba(188, 206, 255, 0.42), rgba(168, 228, 255, 0));
-  opacity: 0.55;
-  pointer-events: none;
+.main-content .section:nth-of-type(odd) {
+  background: #fff;
 }
 
-.section::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(115deg, rgba(255, 255, 255, 0.34) 0%, rgba(255, 255, 255, 0.06) 38%, rgba(167, 209, 255, 0.12) 62%, rgba(255, 255, 255, 0.34) 100%);
-  transform: translateX(-120%);
-  animation: glassShimmer 12s ease-in-out infinite;
-  pointer-events: none;
+.main-content .section:nth-of-type(even) {
+  background: var(--background-alt);
 }
 
-.section-title {
-  position: relative;
-  margin: 0 0 1.85rem;
-  font-size: 1.9rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--heading);
-  display: inline-flex;
-  align-items: center;
-  padding-right: 3.5rem;
-}
-
-.section-title::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: -0.6rem;
-  width: 84px;
-  height: 4px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(176, 199, 255, 0.95), rgba(171, 225, 255, 0.5));
+.section[id] {
+  scroll-margin-top: calc(var(--nav-height) + 1rem);
 }
 
 .section-header {
-  display: grid;
-  gap: 0.6rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
 }
 
 .section-kicker {
-  margin: 0;
-  font-size: 0.85rem;
-  letter-spacing: 0.3em;
+  margin: 0 0 0.5rem;
+  color: var(--muted);
   text-transform: uppercase;
-  color: rgba(85, 106, 155, 0.9);
+  letter-spacing: 0.1em;
+  font-size: 0.78rem;
   font-weight: 600;
 }
 
-.section-subtitle {
+.section-title {
   margin: 0;
-  color: rgba(72, 88, 126, 0.86);
-  max-width: 640px;
+  color: var(--text-primary);
+  font-size: clamp(1.45rem, 2.8vw, 2rem);
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  padding-left: 0.8rem;
+  border-left: 4px solid var(--primary);
+}
+
+.section-subtitle {
+  margin: 0.8rem 0 0;
+  color: var(--text-secondary);
+  max-width: 68ch;
+}
+
+.section-grid,
+.card-grid,
+.stat-grid,
+.service-columns {
+  display: grid;
+  gap: 1rem;
 }
 
 .section-grid {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-}
-
-.highlight-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.85rem;
-}
-
-.highlight-list li {
-  padding: 0.85rem 1rem;
-  border-radius: 16px;
-  border: 1px solid rgba(157, 190, 255, 0.3);
-  background: rgba(239, 248, 255, 0.62);
-  color: rgba(62, 81, 124, 0.92);
-  box-shadow: inset 0 0 18px rgba(192, 219, 255, 0.3);
-}
-
-.stat-grid {
-  display: grid;
-  gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-}
-
-.stat-card {
-  padding: 1.4rem;
-  border-radius: 20px;
-  border: 1px solid rgba(148, 191, 255, 0.25);
-  background: rgba(255, 255, 255, 0.62);
-  box-shadow: var(--card-shadow);
-}
-
-.stat-value {
-  font-size: 1.7rem;
-  font-weight: 700;
-  margin: 0 0 0.35rem;
-  color: var(--heading);
-}
-
-.stat-label {
-  margin: 0;
-  font-size: 0.95rem;
-  color: rgba(73, 90, 132, 0.88);
-}
-
-.detail-card {
-  padding: 1.6rem;
-  border-radius: 22px;
-  border: 1px solid rgba(148, 191, 255, 0.25);
-  background: rgba(255, 255, 255, 0.62);
-  box-shadow: inset 0 0 24px rgba(193, 221, 255, 0.32);
-}
-
-.detail-card h3 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-  color: var(--heading);
-}
-
-.detail-card ul {
-  margin: 0;
-  padding-left: 1.1rem;
-  color: rgba(70, 88, 130, 0.9);
+  grid-template-columns: 1.35fr 1fr;
+  align-items: start;
 }
 
 .section p {
   margin-top: 0;
-  margin-bottom: 1.1rem;
-  color: rgba(56, 72, 108, 0.92);
+  margin-bottom: 1rem;
+  color: var(--text-secondary);
 }
 
-.section p:last-child {
-  margin-bottom: 0;
-}
-
-.card-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.card {
-  padding: 1.8rem;
-  border-radius: 24px;
-  border: 1px solid var(--card-border);
-  background: var(--card-bg);
-  box-shadow: var(--card-shadow);
-  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
-}
-
-.card:hover {
-  transform: translateY(-6px) scale(1.01);
-  box-shadow: 0 24px 55px rgba(128, 157, 219, 0.3);
-  border-color: rgba(155, 189, 255, 0.6);
-}
-
-.card h3 {
-  margin-top: 0;
-  margin-bottom: 0.85rem;
-  font-size: 1.2rem;
-  color: var(--heading);
-}
-
-.card ul {
+.highlight-list {
   margin: 0;
-  padding-left: 1rem;
-  color: rgba(61, 78, 116, 0.9);
+  padding-left: 1.1rem;
+  color: var(--text-secondary);
 }
 
-.card ul li + li {
-  margin-top: 0.4rem;
+.highlight-list li + li { margin-top: 0.55rem; }
+
+.stat-grid,
+.card-grid,
+.service-columns {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.stat-card,
+.detail-card,
+.card,
+.publication,
+.news-item {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 1.2rem;
+  transition: all var(--motion-med);
+}
+
+.stat-card:hover,
+.card:hover,
+.news-item:hover,
+.publication:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+
+.stat-value {
+  margin: 0;
+  font-size: 1.75rem;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.stat-label {
+  margin: 0.5rem 0 0;
+  color: var(--text-secondary);
+}
+
+.card h3,
+.detail-card h3,
+.service-columns h3,
+.publication__title {
+  margin-top: 0;
+  margin-bottom: 0.65rem;
+  color: var(--text-primary);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.card ul,
+.detail-card ul,
+.service-columns ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--text-secondary);
+}
+
+.card ul li + li,
+.detail-card ul li + li,
+.service-columns ul li + li {
+  margin-top: 0.45rem;
 }
 
 .chip-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.7rem;
+  gap: 0.65rem;
 }
 
 .chip {
-  background: var(--chip-bg);
-  border: 1px solid var(--chip-border);
-  color: var(--chip-text);
-  font-weight: 600;
-  padding: 0.55rem 1rem;
+  padding: 0.45rem 0.8rem;
   border-radius: 999px;
-  font-size: 0.98rem;
-  letter-spacing: 0.01em;
-  box-shadow: inset 0 0 14px rgba(197, 222, 255, 0.6);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  background: #fff;
+  font-weight: 500;
 }
 
-.news-list {
+.news-list,
+.publication-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1.2rem;
+  gap: 0.9rem;
 }
 
 .news-item {
-  display: grid;
-  gap: 0.45rem;
-  border-left: 3px solid var(--news-border);
-  padding-left: 1.2rem;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.8), rgba(236, 245, 255, 0.55));
-  border-radius: 8px;
+  border-left: 4px solid var(--accent);
 }
 
 .news-item time {
+  color: var(--primary);
   font-weight: 600;
-  color: rgba(87, 117, 176, 0.95);
+  font-size: 0.85rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
-.publication-list {
-  display: grid;
-  gap: 1.5rem;
-}
-
-.publication {
-  display: grid;
-  gap: 0.65rem;
-  padding: 1.85rem;
-  border: 1px solid var(--publication-border);
-  border-radius: 24px;
-  background: var(--publication-bg);
-  box-shadow: var(--card-shadow);
-}
-
-.publication__title {
-  margin: 0;
-  font-weight: 600;
-  font-size: 1.18rem;
-  color: var(--heading);
-}
-
-.publication__title a {
-  color: inherit;
-}
-
 .publication__meta {
-  color: rgba(74, 92, 132, 0.88);
-  font-size: 0.98rem;
+  margin: 0;
+  color: var(--text-secondary);
 }
 
 .publication__links {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.85rem;
+  gap: 0.8rem;
 }
 
 .publication__links a {
+  text-decoration: none;
+  color: var(--primary);
   font-weight: 600;
-  color: rgba(111, 161, 236, 0.95);
-  text-decoration: underline;
-  text-decoration-color: rgba(111, 161, 236, 0.45);
 }
 
 .empty-state {
   margin: 0;
-  padding: 1.8rem;
-  border-radius: 20px;
-  border: 1px dashed rgba(159, 191, 255, 0.5);
-  background: rgba(239, 247, 255, 0.55);
-  text-align: center;
-  color: rgba(82, 98, 136, 0.84);
-}
-
-.service-columns {
-  display: grid;
-  gap: 2.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.service-columns h3 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-  color: var(--heading);
-}
-
-.service-columns ul {
-  margin: 0;
-  padding-left: 1rem;
-  color: rgba(61, 78, 116, 0.9);
+  padding: 1rem;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
 }
 
 .site-footer {
-  background: transparent;
-  color: rgba(85, 102, 142, 0.78);
-  padding: 2.5rem 0 3.5rem;
+  border-top: 1px solid var(--border);
+  padding: 2rem 0;
+  color: var(--muted);
   text-align: center;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
+  background: #fff;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 960px) {
   .header-layout {
-    gap: 2.5rem;
-  }
-
-  .identity__avatar {
-    width: 168px;
-    height: 168px;
-  }
-}
-
-@media (max-width: 880px) {
-  .header-layout {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .identity {
-    align-items: flex-start;
+    grid-template-columns: 1fr;
   }
 
   .contact-block {
-    align-items: flex-start;
     text-align: left;
+    justify-items: start;
   }
 
   .contact-block__links {
     justify-content: flex-start;
   }
 
-  .site-nav {
-    justify-content: flex-start;
-    gap: 1.2rem;
-    width: 100%;
-    overflow-x: auto;
+  .section-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stat-grid,
+  .card-grid,
+  .service-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 720px) {
-  .site-nav-wrapper {
-    flex-direction: column;
-    align-items: stretch;
+@media (max-width: 760px) {
+  :root { --nav-height: 64px; }
+
+  .container {
+    width: calc(100% - 1.5rem);
+  }
+
+  .identity {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .identity__text {
+    text-align: center;
+  }
+
+  .identity__affiliations,
+  .hero-ctas {
+    justify-content: center;
   }
 
   .site-nav__toggle {
     display: inline-flex;
-    align-self: flex-end;
+    align-items: center;
+    gap: 0.65rem;
+    border: 1px solid var(--border);
+    background: #fff;
+    color: var(--text-primary);
+    border-radius: var(--radius-sm);
+    padding: 0.48rem 0.8rem;
+    font-weight: 600;
+    font-family: inherit;
   }
 
   .site-nav {
     display: none;
+    position: absolute;
+    top: calc(100% - 0.2rem);
+    left: 0;
+    right: 0;
+    background: #fff;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 0.8rem;
+    box-shadow: var(--shadow-md);
     flex-direction: column;
     align-items: flex-start;
-    gap: 1rem;
-    width: 100%;
-    margin: 0;
-    padding: 1.1rem 1.25rem;
-    border-radius: 20px;
-    overflow: visible;
+    gap: 0.7rem;
   }
 
   .site-nav.is-open {
     display: flex;
   }
-}
 
-@media (max-width: 640px) {
-  .site-header {
-    width: calc(100% - 1rem);
-    border-radius: 22px;
-    margin-top: 0.5rem;
-  }
-
-  .container {
-    width: calc(100% - 2rem);
-  }
-
-  .identity__avatar {
-    width: 148px;
-    height: 148px;
-  }
-
-  .header-layout {
-    gap: 2rem;
-    align-items: center;
-    text-align: center;
-  }
-
-  .identity {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: 1.5rem;
-  }
-
-  .identity__text {
-    max-width: 100%;
-  }
-
-  .identity__affiliations {
-    justify-content: center;
-  }
-
-  .contact-block {
-    width: 100%;
-    align-items: center;
-    text-align: center;
-    gap: 0.45rem;
-  }
-
-  .contact-block__links {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .section {
-    padding: 2.1rem;
-  }
-
-  .section-title {
-    font-size: 1.6rem;
-    padding-right: 2rem;
-  }
-
-  .card {
-    padding: 1.6rem;
-  }
-
-  .publication {
-    padding: 1.65rem;
-  }
-
-  .site-nav {
-    padding: 0.75rem 1.2rem;
-  }
-
-  .main-content {
-    gap: 2.6rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .identity__avatar {
-    width: 132px;
-    height: 132px;
-  }
-
-  .header-layout {
-    padding: 2.75rem 0 1.75rem;
-  }
-
-  .section {
-    padding: 1.65rem;
-    border-radius: 22px;
-  }
-
-  .section-title {
-    font-size: 1.45rem;
-  }
-
-  .card,
-  .publication {
-    padding: 1.45rem;
-    border-radius: 20px;
-  }
-
-  .chip {
-    font-size: 0.92rem;
-    padding: 0.5rem 0.9rem;
-  }
-
-  .news-item {
-    padding-left: 1rem;
-    border-left-width: 2px;
-  }
-}
-
-@keyframes auroraFlow {
-  0% {
-    background-position: 0% 0%, 100% 0%, 50% 50%;
-  }
-  50% {
-    background-position: 100% 50%, 0% 50%, 50% 50%;
-  }
-  100% {
-    background-position: 0% 0%, 100% 0%, 50% 50%;
-  }
-}
-
-@keyframes orbDriftLeft {
-  0% {
-    transform: translate(-35%, -35%) scale(1) rotate(0deg);
-  }
-  50% {
-    transform: translate(-30%, -42%) scale(1.05) rotate(8deg);
-  }
-  100% {
-    transform: translate(-35%, -35%) scale(1) rotate(0deg);
-  }
-}
-
-@keyframes orbDriftRight {
-  0% {
-    transform: translate(-5%, -30%) scale(1) rotate(0deg);
-  }
-  50% {
-    transform: translate(5%, -38%) scale(1.08) rotate(-6deg);
-  }
-  100% {
-    transform: translate(-5%, -30%) scale(1) rotate(0deg);
-  }
-}
-
-@keyframes pulseGlow {
-  0%,
-  100% {
-    opacity: 0.55;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.85;
-    transform: scale(1.08);
-  }
-}
-
-@keyframes float {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-6px);
-  }
-}
-
-@keyframes glassShimmer {
-  0%,
-  100% {
-    transform: translateX(-120%);
-    opacity: 0;
-  }
-  30% {
-    opacity: 0.45;
-  }
-  55% {
-    transform: translateX(120%);
-    opacity: 0.25;
-  }
-}
-
-@keyframes liquidLift {
-  0%,
-  100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-4px);
+  .stat-grid,
+  .card-grid,
+  .service-columns {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
-  }
-}
-
-.section.glass::before,
-.section.glass::after {
-  content: none;
-}
-
-/* --- refinement pass: singular centered header + readability + rhythm --- */
-:root {
-  --accent: #8bb6ff;
-  --radius-sm: 12px;
-  --radius-lg: 20px;
-  --ambient-shadow: 0 18px 40px rgba(8, 16, 32, 0.35);
-  --ambient-shadow-hover: 0 24px 48px rgba(8, 16, 32, 0.42);
-}
-
-body {
-  font-size: 17px;
-  line-height: 1.78;
-  color: rgba(226, 234, 248, 0.92);
-  background:
-    radial-gradient(1200px 600px at 0% 0%, rgba(125, 168, 255, 0.2), transparent 60%),
-    radial-gradient(1200px 700px at 100% 0%, rgba(162, 135, 255, 0.16), transparent 60%),
-    linear-gradient(180deg, #11182b 0%, #0d1424 48%, #0b1120 100%);
-}
-
-body::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.06;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.45) 0.6px, transparent 0.6px);
-  background-size: 3px 3px;
-}
-
-a {
-  color: var(--accent);
-}
-
-a:hover,
-a:focus {
-  color: #b9d2ff;
-  text-shadow: none;
-}
-
-a:focus-visible,
-button:focus-visible {
-  outline: 2px solid rgba(171, 206, 255, 0.85);
-  outline-offset: 2px;
-  border-radius: 8px;
-}
-
-.site-header {
-  width: min(1160px, calc(100% - 2rem));
-  margin: 1rem auto 0;
-  border-radius: var(--radius-lg);
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.2), rgba(225, 238, 255, 0.12));
-  border: 1px solid rgba(163, 193, 255, 0.3);
-  box-shadow: var(--ambient-shadow);
-}
-
-.header-layout,
-.identity,
-.identity__text,
-.contact-block {
-  text-align: center;
-  align-items: center;
-  justify-content: center;
-}
-
-.header-layout,
-.identity {
-  flex-direction: column;
-}
-
-.identity {
-  gap: 1.25rem;
-}
-
-.identity__text {
-  max-width: 70ch;
-}
-
-.identity__name {
-  font-size: clamp(2.65rem, 5vw, 3.8rem);
-}
-
-.identity__role,
-.section-kicker {
-  letter-spacing: 0.22em;
-}
-
-.identity__role {
-  color: rgba(214, 228, 252, 0.9);
-}
-
-.identity__tagline,
-.contact-block,
-.section-subtitle,
-.stat-label,
-.detail-card ul,
-.card ul,
-.publication__meta,
-.service-columns ul,
-.section p {
-  color: rgba(204, 219, 242, 0.9);
-}
-
-.site-nav-wrapper {
-  position: sticky;
-  top: 0.7rem;
-  z-index: 40;
-  margin-top: 0.25rem;
-  padding: 0.45rem 0.65rem;
-  border-radius: var(--radius-sm);
-  border: 1px solid rgba(165, 192, 245, 0.24);
-  background: rgba(13, 21, 38, 0.56);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-}
-
-.site-nav {
-  gap: 1rem;
-  width: 100%;
-  justify-content: center;
-}
-
-.site-nav a {
-  padding: 0.55rem 0.45rem;
-  color: rgba(220, 232, 252, 0.9);
-}
-
-.site-nav a.is-active {
-  color: #dbe9ff;
-}
-
-.site-nav a.is-active::after {
-  transform: scaleX(1);
-}
-
-.main-content {
-  padding: 4.5rem 0 6rem;
-  gap: 4rem;
-}
-
-.section {
-  padding: clamp(4.5rem, 7vw, 6rem) clamp(1.5rem, 3vw, 2.8rem);
-  border-radius: var(--radius-lg);
-  border: 1px solid rgba(154, 182, 236, 0.18);
-  background: rgba(255, 255, 255, 0.04);
-  box-shadow: 0 10px 28px rgba(3, 8, 18, 0.26);
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-}
-
-.section-title {
-  font-size: clamp(1.75rem, 3.5vw, 2.35rem);
-  margin-bottom: 1rem;
-}
-
-.section-subtitle {
-  max-width: 68ch;
-}
-
-.section-grid > div:first-child,
-.section > p,
-.publication-list,
-.service-columns {
-  max-width: 70ch;
-}
-
-.section-grid {
-  align-items: stretch;
-}
-
-.card-grid,
-.service-columns,
-.publication-list,
-.stat-grid {
-  gap: 1.4rem;
-}
-
-.card,
-.publication,
-.stat-card,
-.detail-card,
-.news-item {
-  border-radius: var(--radius-lg);
-  padding: 1.45rem;
-  box-shadow: var(--ambient-shadow);
-  transition: transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease;
-}
-
-.card:hover,
-.publication:hover,
-.stat-card:hover,
-.detail-card:hover,
-.news-item:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--ambient-shadow-hover);
-}
-
-.chip {
-  border-radius: var(--radius-sm);
-}
-
-@media (max-width: 880px) {
-  .header-layout,
-  .identity,
-  .contact-block {
-    align-items: center;
-    text-align: center;
-  }
-}
-
-/* --- redesign: live-gradient top experience --- */
-:root {
-  --top-ink: #f4f7ff;
-  --top-ink-soft: rgba(227, 236, 255, 0.86);
-  --top-link: #d8e7ff;
-  --top-glow: rgba(142, 190, 255, 0.45);
-}
-
-.site-header {
-  position: relative;
-  width: min(1180px, calc(100% - 1.4rem));
-  margin: 0.7rem auto 0;
-  border-radius: 34px;
-  padding-bottom: 1.6rem;
-  border: 1px solid rgba(152, 188, 255, 0.3);
-  background:
-    radial-gradient(120% 180% at 0% 0%, rgba(87, 146, 255, 0.35), rgba(87, 146, 255, 0) 58%),
-    radial-gradient(140% 170% at 100% 0%, rgba(188, 138, 255, 0.28), rgba(188, 138, 255, 0) 62%),
-    linear-gradient(120deg, #111a35 0%, #162347 28%, #1a2f57 52%, #2b2d66 76%, #2b1f4d 100%);
-  background-size: 130% 130%, 130% 130%, 210% 210%;
-  box-shadow: 0 26px 70px rgba(4, 10, 24, 0.46), inset 0 1px 0 rgba(255, 255, 255, 0.18);
-  color: var(--top-ink);
-  overflow: hidden;
-  isolation: isolate;
-  animation: headerGradientFlow 18s ease-in-out infinite;
-}
-
-.site-header::before,
-.site-header::after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  z-index: 0;
-  border-radius: 50%;
-  filter: blur(2px);
-}
-
-.site-header::before {
-  width: 520px;
-  height: 520px;
-  top: -240px;
-  right: -120px;
-  background: radial-gradient(circle at center, rgba(149, 209, 255, 0.36), rgba(149, 209, 255, 0));
-  animation: floatOrbA 16s ease-in-out infinite;
-}
-
-.site-header::after {
-  width: 460px;
-  height: 460px;
-  left: -140px;
-  bottom: -260px;
-  background: radial-gradient(circle at center, rgba(198, 149, 255, 0.3), rgba(198, 149, 255, 0));
-  animation: floatOrbB 19s ease-in-out infinite;
-}
-
-.site-header > .container {
-  position: relative;
-  z-index: 2;
-}
-
-.header-layout {
-  padding: 3.4rem 0 2rem;
-  gap: 1.5rem;
-}
-
-.identity__name,
-.identity__role,
-.identity__tagline,
-.contact-block,
-.contact-block__links a,
-.identity__affiliations li,
-.site-nav a,
-.site-nav__toggle {
-  color: var(--top-ink);
-}
-
-.identity__name {
-  text-shadow: 0 6px 22px rgba(8, 17, 38, 0.45);
-}
-
-.identity__role,
-.contact-block,
-.identity__tagline {
-  color: var(--top-ink-soft);
-}
-
-.identity__avatar {
-  border-radius: 30px;
-  box-shadow: 0 20px 50px rgba(6, 14, 32, 0.52), 0 0 70px rgba(147, 202, 255, 0.42);
-}
-
-.identity__affiliations li {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(185, 214, 255, 0.45);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
-}
-
-.site-nav-wrapper {
-  margin-top: 0.2rem;
-  border-radius: 18px;
-  background: rgba(10, 19, 42, 0.42);
-  border: 1px solid rgba(176, 207, 255, 0.22);
-  backdrop-filter: blur(16px) saturate(140%);
-  -webkit-backdrop-filter: blur(16px) saturate(140%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
-}
-
-.site-nav {
-  color: var(--top-link);
-}
-
-.site-nav a {
-  padding: 0.58rem 0.55rem;
-  border-radius: 10px;
-  transition: color 220ms ease, background-color 220ms ease, transform 220ms ease;
-}
-
-.site-nav a:hover,
-.site-nav a:focus-visible,
-.site-nav a.is-active {
-  color: #ffffff;
-  background: rgba(148, 198, 255, 0.16);
-  transform: translateY(-1px);
-}
-
-.site-nav a::after {
-  background: linear-gradient(90deg, rgba(164, 205, 255, 0.98), rgba(196, 165, 255, 0.88));
-}
-
-.site-nav__toggle {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(189, 218, 255, 0.4);
-}
-
-.site-nav__toggle-line {
-  background: linear-gradient(90deg, rgba(178, 212, 255, 1), rgba(200, 176, 255, 1));
-}
-
-.main-content {
-  padding-top: 3.3rem;
-}
-
-@keyframes headerGradientFlow {
-  0%,
-  100% {
-    background-position: 0% 40%, 100% 40%, 0% 50%;
-  }
-  50% {
-    background-position: 100% 60%, 0% 60%, 100% 50%;
-  }
-}
-
-@keyframes floatOrbA {
-  0%,
-  100% { transform: translate(0, 0) scale(1); }
-  50% { transform: translate(-26px, 22px) scale(1.05); }
-}
-
-@keyframes floatOrbB {
-  0%,
-  100% { transform: translate(0, 0) scale(1); }
-  50% { transform: translate(24px, -18px) scale(1.06); }
-}
-
-@media (max-width: 880px) {
-  .site-header {
-    border-radius: 26px;
-  }
-
-  .header-layout {
-    padding: 2.7rem 0 1.8rem;
-  }
-
-  .site-nav-wrapper {
-    top: 0.45rem;
   }
 }

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: homepage
 ---
 
-<section id="about" class="section glass">
+<section id="about" class="section">
   <div class="section-header">
     <p class="section-kicker">Overview</p>
     <h2 class="section-title">About</h2>
@@ -20,7 +20,7 @@ He is also a visiting student and researcher at the Department of Radiology at H
 Currently serving on the RSNA Radiology AI Trainee Editorial Board, as an AI scientist for RAD-AID international, and as a committee member for SIIM and EUSOMII.
       </p>
     </div>
-    <div class="detail-card glass">
+    <div class="detail-card">
       <h3>Focus Areas</h3>
       <ul>
         <li>Clinical translation of AI tools for imaging workflows</li>
@@ -31,7 +31,7 @@ Currently serving on the RSNA Radiology AI Trainee Editorial Board, as an AI sci
   </div>
 </section>
 
-<section id="snapshot" class="section glass">
+<section id="snapshot" class="section">
   <div class="section-header">
     <p class="section-kicker">Profile Snapshot</p>
     <h2 class="section-title">At a Glance</h2>
@@ -39,15 +39,15 @@ Currently serving on the RSNA Radiology AI Trainee Editorial Board, as an AI sci
   </div>
   <div class="section-grid">
     <div class="stat-grid">
-      <div class="stat-card glass">
+      <div class="stat-card">
         <p class="stat-value">3+</p>
         <p class="stat-label">Academic hubs across Penn, HMS, and MGH</p>
       </div>
-      <div class="stat-card glass">
+      <div class="stat-card">
         <p class="stat-value">6</p>
         <p class="stat-label">Active focus areas in imaging AI</p>
       </div>
-      <div class="stat-card glass">
+      <div class="stat-card">
         <p class="stat-value">4</p>
         <p class="stat-label">Service roles in radiology AI organizations</p>
       </div>
@@ -60,14 +60,14 @@ Currently serving on the RSNA Radiology AI Trainee Editorial Board, as an AI sci
   </div>
 </section>
 
-<section id="laboratories" class="section glass">
+<section id="laboratories" class="section">
   <div class="section-header">
     <p class="section-kicker">Collaborations</p>
     <h2 class="section-title">Laboratories & Collaborations</h2>
     <p class="section-subtitle">Research groups and clinical partners that shape ongoing work in imaging AI.</p>
   </div>
   <div class="card-grid">
-    <article class="card glass">
+    <article class="card">
       <h3>University of Pennsylvania, Penn Medicine</h3>
       <ul>
         <li>Center for Practice Transformation, Department of Radiology</li>
@@ -75,7 +75,7 @@ Currently serving on the RSNA Radiology AI Trainee Editorial Board, as an AI sci
         <li>McBeth Lab, Department of Radiation Oncology</li>
       </ul>
     </article>
-    <article class="card glass">
+    <article class="card">
       <h3>MGH/HMS Martinos Center</h3>
       <ul>
         <li>Quantitative Translational Imaging in Medicine Laboratory (QTIM)</li>
@@ -85,60 +85,60 @@ Currently serving on the RSNA Radiology AI Trainee Editorial Board, as an AI sci
   </div>
 </section>
 
-<section id="interests" class="section glass">
+<section id="interests" class="section">
   <div class="section-header">
     <p class="section-kicker">Expertise</p>
     <h2 class="section-title">Research Interests</h2>
     <p class="section-subtitle">Key topics guiding current research and innovation priorities.</p>
   </div>
   <div class="chip-list">
-    <span class="chip glass glass--light">Onco Imaging </span>
-    <span class="chip glass glass--light">Explainable AI</span>
-    <span class="chip glass glass--light">Large Language Models</span>
-    <span class="chip glass glass--light">Clinical Informatics</span>
-    <span class="chip glass glass--light">Patient-Centered Care</span>
-    <span class="chip glass glass--light">Global Health Informatics</span>
+    <span class="chip">Onco Imaging </span>
+    <span class="chip">Explainable AI</span>
+    <span class="chip">Large Language Models</span>
+    <span class="chip">Clinical Informatics</span>
+    <span class="chip">Patient-Centered Care</span>
+    <span class="chip">Global Health Informatics</span>
   </div>
 </section>
 
-<section id="initiatives" class="section glass">
+<section id="initiatives" class="section">
   <div class="section-header">
     <p class="section-kicker">Initiatives</p>
     <h2 class="section-title">Current Research Directions</h2>
     <p class="section-subtitle">Modular streams that guide active projects, grant work, and cross-institutional studies.</p>
   </div>
   <div class="card-grid">
-    <article class="card glass">
+    <article class="card">
       <h3>Clinical AI Translation</h3>
       <p>Deploying real-world decision support tools with rigorous clinical evaluation and stakeholder feedback loops.</p>
     </article>
-    <article class="card glass">
+    <article class="card">
       <h3>Interventional Imaging Intelligence</h3>
       <p>Advanced imaging analytics for vascular and interventional radiology, from procedural planning to outcomes.</p>
     </article>
-    <article class="card glass">
+    <article class="card">
       <h3>Global Health &amp; Equity</h3>
       <p>Scaling AI that improves access to radiology expertise while maintaining safety and equity metrics.</p>
     </article>
   </div>
 </section>
 
-<section id="news" class="section glass">
+<section id="news" class="section">
   <div class="section-header">
     <p class="section-kicker">Updates</p>
     <h2 class="section-title">Recent Highlights</h2>
     <p class="section-subtitle">Recent awards, publications, and project milestones.</p>
   </div>
   <ul class="news-list">
-    <li class="news-item glass">
+    <li class="news-item">
       <time datetime="2024-05">May 2024</time>
       <p>Our abstract was selected as one of the top 20 abstracts at the 2024 National Neurotrauma Symposium.</p>
     </li>
-    <li class="news-item glass">
+    <li class="news-item">
       <time datetime="2024-05">May 2024</time>
       <p>Received a prestigious trainee travel award from the National Neurotrauma Society.</p>
     </li>
-    <li class="news-item glass">
+    <li class="news-item">
       <time datetime="2024-04">April 2024</time>
       <p>Won the $5k grand prize in the advanced track at the 2024 Philly CodeFest.</p>
     </li>


### PR DESCRIPTION
### Motivation
- Modernize the homepage visuals to an “Academic Minimal + AI Modern” aesthetic while keeping content unchanged, improving hierarchy, accessibility, and responsiveness.
- Centralize palette, spacing, and motion into design tokens so the look can be tuned globally without scattering color values across files.

### Description
- Added a token-driven stylesheet in `assets/css/main.css` with global variables for palette (`--primary`, `--accent`, `--highlight`, `--background`, `--background-alt`, `--text-*`, `--border`), spacing, radii, and motion tokens and refactored component styles to use them.
- Upgraded the hero into a 2-column desktop layout and added three CTAs under the subtitle (`Publications`, `Research`, `Contact`) in `_layouts/homepage.html` with `btn--primary` and `btn--outline` styles and hover/focus states.
- Made the top navigation sticky with subtle blur/shadow in `assets/css/main.css` and added `scroll-margin-top` handling for section anchors so nav links do not get covered by the sticky bar.
- Implemented alternating section backgrounds, a left accent rule for section titles, standardized card/stat/publication/news styles with a shared hover elevation (`translateY(-4px)`), and removed legacy `glass` classes from page and include markup to align with the new visual layer.
- Added `DESIGN_NOTES.md` documenting where tokens live, which components were changed, and how to tweak palette/spacing/motion later.

### Testing
- Attempted a site build with `bundle exec jekyll build`, but dependency installation failed in this environment when running `bundle install` due to `403 Forbidden` responses from `rubygems.org`, so a full static build could not be validated (failure).
- Verified that in-page navigation/CTA anchors resolve to existing section IDs using a lightweight Python check (`python - <<'PY' ...` confirming `missing []`), so anchors point to valid targets (success).
- Ran responsive and DOM-safe adjustments by updating markup and CSS breakpoints and validated mobile stacking via the defined media queries in `assets/css/main.css` (visual/responsive behavior implemented as CSS changes; runtime rendering not built here due to the gem-hosting failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff33317388328a6064d624147f5e5)